### PR TITLE
add MicroProfile category to MicroProfile Starter command

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"commands": [
 			{
 				"command": "extension.microProfileStarter",
-				"title": "MicroProfile Starter"
+				"title": "MicroProfile: MicroProfile Starter"
 			}
 		]
 	},

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 		"commands": [
 			{
 				"command": "extension.microProfileStarter",
-				"title": "MicroProfile: MicroProfile Starter"
+				"category": "MicroProfile",
+				"title": "MicroProfile Starter"
 			}
 		]
 	},


### PR DESCRIPTION
Fix for #11 

Add the MicroProfile category to the MicroProfile Starter Command:
![image](https://user-images.githubusercontent.com/26146482/69843459-9a543d00-1235-11ea-80ad-e1f3b39f2662.png)


Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>