### PR TITLE
add support for MP32 and update version to 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ The extension prompts for the following parameters:
 1. groupId
 2. artifactId 
 3. Java SE version
-4. MicroProfile server
-5. MicroProfile specifications
-6. A folder to generate the project into
+4. MicroProfile version
+5. MicroProfile server
+6. MicroProfile specifications
+7. A folder to generate the project into
 
 The extension will generate a `.zip` file of the starter project, unzip the file into the specified directory and open it in a VS Code window.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "mp-starter-vscode-ext",
 	"displayName": "MicroProfile Starter",
 	"description": "VS Code extension starter for Eclipse MicroProfile",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"publisher": "MicroProfile-Community",
 	"preview": true,
 	"license": "EPL-2.0",

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -1,4 +1,5 @@
 const mpVersions = {
+    MP32: 'version 3.2',
     MP30: 'version 3.0',
     MP22: 'version 2.2',
     MP21: 'version 2.1',

--- a/src/util/starter.ts
+++ b/src/util/starter.ts
@@ -27,9 +27,13 @@ export async function generateProject(): Promise<void> {
 
             var mpDict = JSON.parse(body);
             var mpVersions = Object.keys(mpDict.configs);
-
             // get descriptive values of MicroProfile Versions
             let mpVersionsMapped = await mapToPropertiesFile("mpVersions", mpVersions);
+            // if one of the versions is null, remove it from the list
+            let filterdArray = mpVersionsMapped.filter(x => x != null) as string[];
+            if (filterdArray.length !== mpVersionsMapped.length) {
+                mpVersionsMapped = filterdArray;
+            }
 
             // prompt for groupId
             const groupId: string | undefined = await vscode.window.showInputBox(Object.assign({


### PR DESCRIPTION
Fix for MP Versions error.

Added MicroProfile version 3.2 to the properties file. Also added an additional check so that this error will not happen again. If the extension's properties versions do not include one of the MP versions returned from the API, do not display that version to the user.

Also incremented the version of the extension to 0.2.1.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>