### PR TITLE
Add progress bar and open project option

### DIFF
--- a/src/util/starter.ts
+++ b/src/util/starter.ts
@@ -98,18 +98,15 @@ export async function generateProject(): Promise<void> {
             // open the unzipped folder in a new VS Code window
             const uriPath = vscode.Uri.file(path.join(targetDirString, artifactId));
             // prompt user whether they want to add project to current workspace or open in a new window
-            vscode.window
-              .showInformationMessage(
-                "MicroProfile starter project generated.  Would you like to add your project to the current workspace or open it in a new window?",
-                ...["Add to current workspace", "Open in new window"]
-              )
-              .then(async selection => {
-                if (selection === "Add to current workspace") {
-                  vscode.workspace.updateWorkspaceFolders(0, 0, { uri: uriPath });
-                } else {
-                  await vscode.commands.executeCommand("vscode.openFolder", uriPath, true);
-                }
-              });
+            const selection = await vscode.window.showInformationMessage(
+              "MicroProfile starter project generated.  Would you like to add your project to the current workspace or open it in a new window?",
+              ...["Add to current workspace", "Open in new window"]
+            );
+            if (selection === "Add to current workspace") {
+              vscode.workspace.updateWorkspaceFolders(0, 0, { uri: uriPath });
+            } else {
+              await vscode.commands.executeCommand("vscode.openFolder", uriPath, true);
+            }
           }
         });
       }

--- a/src/util/starter.ts
+++ b/src/util/starter.ts
@@ -82,19 +82,38 @@ export async function generateProject(): Promise<void> {
       body: JSON.stringify(requestPayload),
     };
 
-    await util.downloadFile(requestOptions, zipPath);
-
-    extract(zipPath, { dir: targetDirString }, async function(err: any) {
-      if (err !== undefined) {
-        console.error(err);
-        vscode.window.showErrorMessage("Failed to extract the MicroProfile starter project.");
-      } else {
-        // open the unzipped folder in a new VS Code window
-        const uri = vscode.Uri.file(path.join(targetDirString, artifactId));
-        const openInNewWindow = vscode.workspace.workspaceFolders !== undefined;
-        await vscode.commands.executeCommand("vscode.openFolder", uri, openInNewWindow);
+    // show a progress bar as the zip file is being downloaded
+    vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: "Generating the MicroProfile starter project...",
+      },
+      async () => {
+        await util.downloadFile(requestOptions, zipPath);
+        extract(zipPath, { dir: targetDirString }, async function(err: any) {
+          if (err !== undefined) {
+            console.error(err);
+            vscode.window.showErrorMessage("Failed to extract the MicroProfile starter project.");
+          } else {
+            // open the unzipped folder in a new VS Code window
+            const uriPath = vscode.Uri.file(path.join(targetDirString, artifactId));
+            // prompt user whether they want to add project to current workspace or open in a new window
+            vscode.window
+              .showInformationMessage(
+                "MicroProfile starter project generated.  Would you like to add your project to the current workspace or open it in a new window?",
+                ...["Add to current workspace", "Open in new window"]
+              )
+              .then(async selection => {
+                if (selection === "Add to current workspace") {
+                  vscode.workspace.updateWorkspaceFolders(0, 0, { uri: uriPath });
+                } else {
+                  await vscode.commands.executeCommand("vscode.openFolder", uriPath, true);
+                }
+              });
+          }
+        });
       }
-    });
+    );
   } catch (e) {
     console.error(e);
     vscode.window.showErrorMessage("Failed to generate a MicroProfile starter project");


### PR DESCRIPTION
1. Fix for #19 - add a progress bar while generating extension
2. Add an option to add the generated project to the current vs code workspace or open in a new window.
<img width="379" alt="Screen Shot 2020-01-29 at 11 44 51 AM" src="https://user-images.githubusercontent.com/26146482/73377310-d5520b80-428c-11ea-9f77-49483585837f.png">

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>