### PR TITLE
Updated extension to align with MP Starter 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 The MicroProfile Starter extension provides support for generating a MicroProfile Maven project with examples based on the Eclipse MicroProfile Starter project (https://start.microprofile.io/) by the MicroProfile community. You will be able to generate a project by choosing a MicroProfile version, server and specifications, such as CDI, Config, Health Check, Metrics, and more. This extension is hosted under the MicroShed organization.
 
 ## Quick Start
-- Install the extension 
-- Launch the VS Code command palette, then select `MicroProfile: Generate a new MicroProfile starter project` to run the extension
+- Install the extension
+- Launch the VS Code command palette, then select `MicroProfile Starter` to run the extension
 
 ## Input
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,18 @@
 The MicroProfile Starter extension provides support for generating a MicroProfile Maven project with examples based on the Eclipse MicroProfile Starter project (https://start.microprofile.io/) by the MicroProfile community. You will be able to generate a project by choosing a MicroProfile version, server and specifications, such as CDI, Config, Health Check, Metrics, and more. This extension is hosted under the MicroShed organization.
 
 ## Quick Start
-
-- Install the extension
-- Launch the VS Code command palette, then select `MicroProfile Starter` to run the extension
+- Install the extension 
+- Launch the VS Code command palette, then select `MicroProfile: Generate a new MicroProfile starter project` to run the extension
 
 ## Input
 
 The extension prompts for the following parameters:
 
 1. groupId
-2. artifactId
-3. Java SE version
-4. MicroProfile version
-5. MicroProfile server
+2. artifactId 
+3. MicroProfile version
+4. MicroProfile server
+5. Java SE version
 6. MicroProfile specifications
 7. A folder to generate the project into
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mp-starter-vscode-ext",
   "displayName": "MicroProfile Starter",
   "description": "Generate Java Microservice Maven projects using Eclipse MicroProfile",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "MicroProfile-Community",
   "preview": true,
   "license": "Apache-2.0",

--- a/src/util/starter.ts
+++ b/src/util/starter.ts
@@ -6,7 +6,7 @@ import fetch from "node-fetch";
 
 export async function generateProject(): Promise<void> {
   try {
-    const mpSupportResponse = await fetch("https://start.microprofile.io/api/2/supportMatrix");
+    const mpSupportResponse = await fetch("https://start.microprofile.io/api/3/supportMatrix");
     if (mpSupportResponse.status >= 400 && mpSupportResponse.status < 600) {
       throw new Error(`Bad response ${mpSupportResponse.status}: ${mpSupportResponse.statusText}`);
     }
@@ -27,11 +27,6 @@ export async function generateProject(): Promise<void> {
       return;
     }
 
-    const javaSEVersion = await util.askForJavaSEVersion();
-    if (javaSEVersion === undefined) {
-      return;
-    }
-
     const mpVersion = await util.askForMPVersion(allMpVersions);
     if (mpVersion === undefined) {
       return;
@@ -40,6 +35,11 @@ export async function generateProject(): Promise<void> {
     // ask user to select one of the servers that are available for the version of mp they selected
     const mpServer = await util.askForMPServer(mpConfigurations[mpVersion].supportedServers);
     if (mpServer === undefined) {
+      return;
+    }
+
+    const javaSEVersion = await util.askForJavaSEVersion(mpVersion);
+    if (javaSEVersion === undefined) {
       return;
     }
 

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -41,13 +41,21 @@ export async function askForArtifactID(): Promise<string | undefined> {
   });
 }
 
-export async function askForJavaSEVersion(): Promise<string | undefined> {
+export async function askForJavaSEVersion(mpVersion: string): Promise<string | undefined> {
   const SUPPORTED_JAVA_SE_VERSIONS = ["SE8"];
+  const SUPPORTED_JAVA_SE_VERSIONS_MP32 = ["SE8", "SE11"];
 
-  return await vscode.window.showQuickPick(SUPPORTED_JAVA_SE_VERSIONS, {
-    ignoreFocusOut: true,
-    placeHolder: "Select a Java SE version.",
-  });
+  if (mpVersion === "MP32") {
+    return await vscode.window.showQuickPick(SUPPORTED_JAVA_SE_VERSIONS_MP32, {
+      ignoreFocusOut: true,
+      placeHolder: "Select a Java SE version.",
+    });
+  } else {
+    return await vscode.window.showQuickPick(SUPPORTED_JAVA_SE_VERSIONS, {
+      ignoreFocusOut: true,
+      placeHolder: "Select a Java SE version.",
+    });
+  }
 }
 
 export async function askForMPVersion(mpVersions: string[]): Promise<string | undefined> {


### PR DESCRIPTION
Fix for #25 

- For MP Version 3.2, support Java 8 and Java 11 
- Use newest version of api (https://start.microprofile.io/api/3/supportMatrix)
- Reorder selection so that the user must first select the MP version and server before they select the Java SE version
- Update extension to version `0.2.2`

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>