### PR TITLE
Do not open project if user dismisses open project prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/MicroProfile-Community.mp-starter-vscode-ext.svg "Current Release")](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.mp-starter-vscode-ext)
 [![Build Status](https://travis-ci.org/MicroShed/mp-starter-vscode-ext.svg?branch=master)](https://travis-ci.org/MicroShed/mp-starter-vscode-ext)
 
-The MicroProfile Starter extension provides support for generating a MicroProfile Maven project with examples based on the Eclipse MicroProfile Starter project (https://start.microprofile.io/) by the MicroProfile community. You will be able to generate a project by choosing a MicroProfile version, server and specifications, such as CDI, Config, Health Check, Metrics, and more. This extension is hosted under the MicroShed organization.
+The MicroProfile Starter extension provides support for generating a MicroProfile Maven project with examples based on the Eclipse MicroProfile Starter project (https://start.microprofile.io/) by the MicroProfile community. You will be able to generate a project by choosing a MicroProfile version, server and specifications, such as CDI, Config, Health, Metrics, and more. This extension is hosted under the MicroShed organization.
 
 ## Quick Start
 - Install the extension

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -18,3 +18,8 @@ export const MP_SERVER_LABELS: Record<string, string> = {
   TOMEE: "Apache TomEE 8.00-M2",
   WILDFLY_SWARM: "WildFly Swarm",
 };
+
+export const OPEN_NEW_PROJECT_OPTIONS = {
+  ADD_CURRENT_WORKSPACE: "Add to current workspace",
+  OPEN_NEW_WINDOW: "Open in new window",
+};

--- a/src/util/starter.ts
+++ b/src/util/starter.ts
@@ -3,6 +3,7 @@ import * as extract from "extract-zip";
 import * as util from "./util";
 import * as path from "path";
 import fetch from "node-fetch";
+import { OPEN_NEW_PROJECT_OPTIONS } from "../properties";
 
 export async function generateProject(): Promise<void> {
   try {
@@ -95,24 +96,27 @@ export async function generateProject(): Promise<void> {
             console.error(err);
             vscode.window.showErrorMessage("Failed to extract the MicroProfile starter project.");
           } else {
-            // open the unzipped folder in a new VS Code window
-            const uriPath = vscode.Uri.file(path.join(targetDirString, artifactId));
-            // prompt user whether they want to add project to current workspace or open in a new window
-            const selection = await vscode.window.showInformationMessage(
-              "MicroProfile starter project generated.  Would you like to add your project to the current workspace or open it in a new window?",
-              ...["Add to current workspace", "Open in new window"]
-            );
-            if (selection === "Add to current workspace") {
-              vscode.workspace.updateWorkspaceFolders(0, 0, { uri: uriPath });
-            } else {
-              await vscode.commands.executeCommand("vscode.openFolder", uriPath, true);
-            }
-
             try {
               await util.deleteFile(zipPath);
             } catch (e) {
               console.error(e);
               vscode.window.showErrorMessage(`Failed to delete file ${zipName}`);
+            }
+
+            // open the unzipped folder in a new VS Code window
+            const uriPath = vscode.Uri.file(path.join(targetDirString, artifactId));
+            // prompt user whether they want to add project to current workspace or open in a new window
+            const selection = await vscode.window.showInformationMessage(
+              "MicroProfile starter project generated.  Would you like to add your project to the current workspace or open it in a new window?",
+              ...[
+                OPEN_NEW_PROJECT_OPTIONS.ADD_CURRENT_WORKSPACE,
+                OPEN_NEW_PROJECT_OPTIONS.OPEN_NEW_WINDOW,
+              ]
+            );
+            if (selection === OPEN_NEW_PROJECT_OPTIONS.ADD_CURRENT_WORKSPACE) {
+              vscode.workspace.updateWorkspaceFolders(0, 0, { uri: uriPath });
+            } else if (selection === OPEN_NEW_PROJECT_OPTIONS.OPEN_NEW_WINDOW) {
+              await vscode.commands.executeCommand("vscode.openFolder", uriPath, true);
             }
           }
         });


### PR DESCRIPTION
* Do not open project if user dismisses open project prompt
* Also delete zip before waiting on user to select an option for where to open the project.

Signed-off-by: Ryan Zegray <ryan.zegray@gmail.com>
